### PR TITLE
Update to version 1.0.5

### DIFF
--- a/chat.revolt.RevoltDesktop.metainfo.xml
+++ b/chat.revolt.RevoltDesktop.metainfo.xml
@@ -25,7 +25,7 @@
   <releases>
     <release date="2022-05-23" version="1.0.5">
       <description>
-        Small quality of life improvements and minor bug fixes:
+        Bug fixes:
         <ul>
           <li>fix: use getConfig() instead of store.getConfig to prevent error on quit.</li>
           <li>feat: use monochrome tray icon and fix tray icon on macOS.</li>

--- a/chat.revolt.RevoltDesktop.metainfo.xml
+++ b/chat.revolt.RevoltDesktop.metainfo.xml
@@ -23,6 +23,15 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release date="2022-05-23" version="1.0.5">
+      <description>
+        Small quality of life improvements and minor bug fixes:
+        <ul>
+          <li>fix: use getConfig() instead of store.getConfig to prevent error on quit.</li>
+          <li>feat: use monochrome tray icon and fix tray icon on macOS.</li>
+        </ul>
+      </description>
+    </release>
     <release date="2022-05-10" version="1.0.4">
       <description>
         Small quality of life improvements and minor bug fixes:

--- a/chat.revolt.RevoltDesktop.yaml
+++ b/chat.revolt.RevoltDesktop.yaml
@@ -49,12 +49,12 @@ modules:
     subdir: main
     sources:
       - type: archive
-        url: https://github.com/revoltchat/desktop/archive/v1.0.4.tar.gz
-        sha256: e9ed82773677a9ec1133dbd0fd0b1efa346cb6da44d15ff28879256333c3ca64
+        url: https://github.com/revoltchat/desktop/archive/v1.0.5.tar.gz
+        sha256: 4130d8acc7d8a7d10a5041aa5bfcba54233861beefb8181c4e5dbb1357090a89
         dest: main
       - type: archive
-        url: https://github.com/revoltchat/desktop/releases/download/v1.0.4/revolt-desktop-1.0.4.tar.gz
-        sha256: 943459bdcd843befaba8d87bf9aa7947085aee71ba43759df55fa3808587831d
+        url: https://github.com/revoltchat/desktop/releases/download/v1.0.5/revolt-desktop-1.0.5.tar.gz
+        sha256: 34a64a341393ccadf847a69f6dd3f28d8d42af552cc89ae078ecd20bcae1c44c
         dest: main
         strip-components: 0
       - type: script

--- a/chat.revolt.RevoltDesktop.yaml
+++ b/chat.revolt.RevoltDesktop.yaml
@@ -40,7 +40,7 @@ modules:
       env:
         npm_config_nodedir: /usr/lib/sdk/node16
     build-commands:
-      - cp -a revolt-desktop-1.0.4 /app/main
+      - cp -a revolt-desktop-1.0.5 /app/main
       - desktop-file-edit --set-icon=$FLATPAK_ID revolt-desktop.desktop
       - install -Dm644 revolt-desktop.desktop /app/share/applications/$FLATPAK_ID.desktop
       - install -Dm644 build/icons/icon.png /app/share/icons/hicolor/512x512/apps/$FLATPAK_ID.png


### PR DESCRIPTION
This updates the links and hashes of the revolt desktop app,
and adds a new release description to the .xml