### PR TITLE
Update chat.revolt.RevoltDesktop.yaml

### DIFF
--- a/chat.revolt.RevoltDesktop.yaml
+++ b/chat.revolt.RevoltDesktop.yaml
@@ -1,9 +1,9 @@
 app-id: chat.revolt.RevoltDesktop
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
-base-version: '22.08'
+base-version: '23.08'
 sdk-extensions:
 - org.freedesktop.Sdk.Extension.node18
 command: revolt-desktop

--- a/chat.revolt.RevoltDesktop.yaml
+++ b/chat.revolt.RevoltDesktop.yaml
@@ -5,7 +5,7 @@ sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
 base-version: '24.08'
 sdk-extensions:
-- org.freedesktop.Sdk.Extension.node18
+- org.freedesktop.Sdk.Extension.node22
 command: revolt-desktop
 separate-locales: false
 finish-args:
@@ -31,7 +31,7 @@ modules:
 - name: revolt
   buildsystem: simple
   build-options:
-    append-path: /usr/lib/sdk/node18/bin
+    append-path: /usr/lib/sdk/node22/bin
     env:
       npm_config_nodedir: /usr/lib/sdk/node22
   build-commands:

--- a/chat.revolt.RevoltDesktop.yaml
+++ b/chat.revolt.RevoltDesktop.yaml
@@ -33,7 +33,7 @@ modules:
   build-options:
     append-path: /usr/lib/sdk/node18/bin
     env:
-      npm_config_nodedir: /usr/lib/sdk/node18
+      npm_config_nodedir: /usr/lib/sdk/node22
   build-commands:
   - cp -a revolt-desktop /app/
   - install -Dm775 revolt-desktop.sh /app/bin/revolt-desktop

--- a/chat.revolt.RevoltDesktop.yaml
+++ b/chat.revolt.RevoltDesktop.yaml
@@ -1,9 +1,9 @@
 app-id: chat.revolt.RevoltDesktop
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
-base-version: '23.08'
+base-version: '24.08'
 sdk-extensions:
 - org.freedesktop.Sdk.Extension.node18
 command: revolt-desktop


### PR DESCRIPTION
A Build Test so that the revolt SDK and Base will no longer be EOL, uncertain of it's effectiveness.