### PR TITLE
Enable ARM Support

### DIFF
--- a/chat.revolt.RevoltDesktop.yaml
+++ b/chat.revolt.RevoltDesktop.yaml
@@ -11,7 +11,8 @@ separate-locales: false
 finish-args:
   # Xorg access for graphics
 - --share=ipc
-- --socket=x11
+- --socket=fallback-x11
+- --socket=wayland
   # Required to provide Call functionality
 - --socket=pulseaudio
 - --device=all
@@ -43,8 +44,14 @@ modules:
 
   sources:
   - type: archive
-    url: https://github.com/revoltchat/desktop/releases/download/v1.0.6/revolt-desktop-1.0.6.tar.gz
-    sha256: eba79090ca83fa0d549cb3df062a44c76b940cdd96aec9d7b7823a1399f694ad
+    only-arches: [x86_64]
+    url: https://github.com/revoltchat/desktop/releases/download/v1.0.8/revolt-desktop-1.0.8.tar.gz
+    sha256: 60738e4fc2574ce1d2d4ff4ca18dfac93e2f53d81bcbbbb4e40f5751f428a4ae
+    dest: revolt-desktop
+  - type: archive
+    only-arches: [aarch64]
+    url: https://github.com/revoltchat/desktop/releases/download/v1.0.8/revolt-desktop-1.0.8-arm64.tar.gz
+    sha256: 758bc74914de8ff2a9c4faa6a3f09a19ef93cd65d2310da7450a3c082c6407da
     dest: revolt-desktop
   - type: script
     dest-filename: revolt-desktop.sh

--- a/chat.revolt.RevoltDesktop.yaml
+++ b/chat.revolt.RevoltDesktop.yaml
@@ -11,8 +11,7 @@ separate-locales: false
 finish-args:
   # Xorg access for graphics
 - --share=ipc
-- --socket=fallback-x11
-- --socket=wayland
+- --socket=x11
   # Required to provide Call functionality
 - --socket=pulseaudio
 - --device=all

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,0 @@
-{
-  "skip-arches": ["aarch64"]
-}


### PR DESCRIPTION
Since upstream now packages ARM64 directly, it should be easy enough to enable support for the Flatpak as well now. 

Edit: this obviously updates to the newest version. I was too lazy to make yet another PR for that, but since there is no reason to enable it without updating, as older releases weren't built for ARM that shouldn't be an issue.