### PR TITLE
Add `.gitignore` File

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+.flatpak-builder/


### PR DESCRIPTION
Simple enough, adds a pretty standard `.gitignore` file since those are pretty much defaults for Flatpak Builder. Simply a QoL improvement.