### PR TITLE
Enable Native Wayland Support

### DIFF
--- a/chat.revolt.RevoltDesktop.yaml
+++ b/chat.revolt.RevoltDesktop.yaml
@@ -28,6 +28,9 @@ finish-args:
 - --talk-name=org.freedesktop.Notifications
 - --talk-name=org.kde.StatusNotifierWatcher
 
+  # Enable Wayland support if available
+- --env=ELECTRON_OZONE_PLATFORM_HINT=auto
+
 modules:
   # Build and install revolt
 - name: revolt
@@ -52,7 +55,7 @@ modules:
     dest-filename: revolt-desktop.sh
     commands:
     # TMPDIR env variable fixes the tray icon issue (#6)
-    - env TMPDIR="$XDG_RUNTIME_DIR/app/${FLATPAK_ID:-chat.revolt.RevoltDesktop}" zypak-wrapper /app/revolt-desktop/revolt-desktop --ozone-platform-hint=auto --enable-features=WaylandWindowDecorations "$@"
+    - env TMPDIR="$XDG_RUNTIME_DIR/app/${FLATPAK_ID:-chat.revolt.RevoltDesktop}" zypak-wrapper /app/revolt-desktop/revolt-desktop "$@"
   - type: file
     path: chat.revolt.RevoltDesktop.desktop
   - type: file

--- a/chat.revolt.RevoltDesktop.yaml
+++ b/chat.revolt.RevoltDesktop.yaml
@@ -9,9 +9,11 @@ sdk-extensions:
 command: revolt-desktop
 separate-locales: false
 finish-args:
-  # Xorg access for graphics
 - --share=ipc
-- --socket=x11
+  # Wayland socket for displaying the app
+- --socket=wayland
+  # X11 fallback socket in case the user is not running Wayland
+- --socket=fallback-x11
   # Required to provide Call functionality
 - --socket=pulseaudio
 - --device=all
@@ -50,7 +52,7 @@ modules:
     dest-filename: revolt-desktop.sh
     commands:
     # TMPDIR env variable fixes the tray icon issue (#6)
-    - env TMPDIR="$XDG_RUNTIME_DIR/app/${FLATPAK_ID:-chat.revolt.RevoltDesktop}" zypak-wrapper /app/revolt-desktop/revolt-desktop "$@"
+    - env TMPDIR="$XDG_RUNTIME_DIR/app/${FLATPAK_ID:-chat.revolt.RevoltDesktop}" zypak-wrapper /app/revolt-desktop/revolt-desktop --ozone-platform-hint=auto --enable-features=WaylandWindowDecorations "$@"
   - type: file
     path: chat.revolt.RevoltDesktop.desktop
   - type: file


### PR DESCRIPTION
This adds native Wayland support, which should be much preferred if available. Most Electron apps are doing this now, as support has been pretty stable on the most recent Electron releases. Some stick to opt-in, but those are mostly outliers like Discord, since upstream still uses a pretty outdated version. Over all this would lead to a much better OOTB experience for most users these days, as more and more users are on Wayland with the biggest distros defaulting to it. Also, since things like HiDPI screens are obviously becoming more common, sticking to XWayland can lead to blurry looking apps on most setups, causing confusion for non-technical users.

This also switches on the x11-fallback socket instead of the x11 socket, since that is the intended configuration for apps that work natively on Wayland, which this Flatpak is correctly configured to do ([reference](https://docs.flatpak.org/en/latest/sandbox-permissions.html)).

> Applications that do not support native Wayland should use only --socket=x11 and applications that do, should use --socket=fallback-x11 and --socket=wayland. The two configurations here will make the application work on both X11 and Wayland sessions of the desktop environment.