### PR TITLE
Remove Unused Permission

### DIFF
--- a/chat.revolt.RevoltDesktop.yaml
+++ b/chat.revolt.RevoltDesktop.yaml
@@ -23,7 +23,6 @@ finish-args:
 - --filesystem=xdg-videos:ro
 
   # Required for notifications in various desktop environments
-- --talk-name=org.freedesktop.Notifications
 - --talk-name=org.kde.StatusNotifierWatcher
 
 modules:


### PR DESCRIPTION
This removes the `--talk-name=org.freedesktop.Notifications` permission, as it is not needed any more with the 24.08 version of the Electron BaseApp. For more information, see [the relevant GitLab news](https://gitlab.gnome.org/GNOME/libnotify/-/blob/69aff6e5fa2842e00b409c348bd73188548828b3/NEWS#L25). I tested this build and everything works as expected, including notifications.