### PR TITLE
Fix Custom Mouse Cursors

### DIFF
--- a/chat.revolt.RevoltDesktop.yaml
+++ b/chat.revolt.RevoltDesktop.yaml
@@ -29,6 +29,8 @@ finish-args:
 
   # Enable Wayland support if available
 - --env=ELECTRON_OZONE_PLATFORM_HINT=auto
+  # Ensure that custom mouse cursors are used
+- --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
 
 modules:
   # Build and install revolt


### PR DESCRIPTION
This adds `XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons` to the manifest to ensure availability of custom mouse cursor themes in both Wayland and X11 mode.